### PR TITLE
Use `model id` + latest version

### DIFF
--- a/fastchat/serve/api_provider.py
+++ b/fastchat/serve/api_provider.py
@@ -163,7 +163,7 @@ def ai2_api_stream_iter(model_name,
     # get keys and needed values
     ai2_key = api_key or os.environ.get('AI2_API_KEY')
     api_base = api_base or "https://inferd.allen.ai/api/v1/infer"
-    model_id = "mov_01hhndc7e8k2s9x379ge8sm8xs"
+    model_id = "mod_01hhgcga70c91402r9ssyxekan"
 
     # Make requests
     gen_params = {
@@ -174,13 +174,19 @@ def ai2_api_stream_iter(model_name,
         "max_new_tokens": max_new_tokens,
     }
     logger.info(f"==== request ====\n{gen_params}")
+
+    # AI2 uses vLLM, which requires that `top_p` be 1.0 for greedy sampling:
+    # https://github.com/vllm-project/vllm/blob/v0.1.7/vllm/sampling_params.py#L156-L157
+    if temperature == 0.0 and top_p < 1.0:
+        raise ValueError("top_p must be 1 when temperature is 0.0")
+
     res = post(api_base,
         stream=True,
         headers={
             "Authorization": f"Bearer {ai2_key}"
         },
         json={
-            "model_version_id": model_id,
+            "model_id": model_id,
             # This input format is specific to the Tulu2 model. Other models
             # may require different input formats. See the model's schema
             # documentation on InferD for more information.


### PR DESCRIPTION
This updates the code to use `model_id` instead of `model_version_id`, this way the latest, released version will always be used. This is potentially less stable, but means we don't have to update the version ID with each model release.

I also added a little code to handle the case where greedy sampling is used to prevent the error that's raised by vLLM.

I tested this by running this script:

```python
# test_ai2.py
from fastchat.serve.api_provider import ai2_api_stream_iter

prompts = [
    [
        { "role": "user", "content": "are labradors unicorns?" }
    ],
    [
        { "role": "user", "content": "are turtles real?" },
        { "role": "assistant", "content": "of course not" },
        { "role": "user", "content": "please explain" },
    ],
]

for (i, messages) in enumerate(prompts):
    print()
    print(f"Prompt {i}:")
    for chunk in ai2_api_stream_iter(model_name="tulu2", messages=messages, temperature=1.0,
                                     top_p=1.0, max_new_tokens=256):
        print(chunk["text"])
    print()
```

Things seemed to work. Tulu2 asserts it was wrong, Turtles are in fact real:

> I apologize, my previous answer was incorrect. Turtles are indeed real animals that exist in various parts of the world. They belong to the order Testudines, and there are many different species of turtles, some of which are aquatic, while others are terrestrial or semi-terrestrial. They have a distinctive appearance, with a protective shell covering their body and a head, legs, and tail that can be retracted into the shell for protection. Turtles are reptiles, and they are cold-blooded, which means that their body temperature is regulated by the environment around them. Some species of turtles are endangered due to habitat loss, pollution, and hunting.
